### PR TITLE
Comments snippets xcode9 bug

### DIFF
--- a/CodeSnippets/Constants.codesnippet
+++ b/CodeSnippets/Constants.codesnippet
@@ -6,10 +6,10 @@
 	<string>Constants</string>
 	<key>IDECodeSnippetCompletionScopes</key>
 	<array>
-		<string>StringOrComment</string>
+		<string>All</string>
 	</array>
 	<key>IDECodeSnippetContents</key>
-	<string>MARK: - Constants</string>
+	<string>// MARK: - Constants</string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>19B5FE13-52D3-49E1-B64C-809E62F5F483</string>
 	<key>IDECodeSnippetLanguage</key>

--- a/CodeSnippets/IBActions.codesnippet
+++ b/CodeSnippets/IBActions.codesnippet
@@ -6,10 +6,10 @@
 	<string>IBActions</string>
 	<key>IDECodeSnippetCompletionScopes</key>
 	<array>
-		<string>StringOrComment</string>
+		<string>All</string>
 	</array>
 	<key>IDECodeSnippetContents</key>
-	<string>MARK: - IBActions</string>
+	<string>// MARK: - IBActions</string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>01C66613-3831-4DB9-9D4F-96EEEF538945</string>
 	<key>IDECodeSnippetLanguage</key>

--- a/CodeSnippets/IBOutlets.codesnippet
+++ b/CodeSnippets/IBOutlets.codesnippet
@@ -6,10 +6,10 @@
 	<string>IBOutlets</string>
 	<key>IDECodeSnippetCompletionScopes</key>
 	<array>
-		<string>StringOrComment</string>
+		<string>All</string>
 	</array>
 	<key>IDECodeSnippetContents</key>
-	<string>MARK: - IBOutlets</string>
+	<string>// MARK: - IBOutlets</string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>9E24F6FE-6618-48C6-B2B6-79376FDEAB32</string>
 	<key>IDECodeSnippetLanguage</key>

--- a/CodeSnippets/InitializationAndDeinitialization.codesnippet
+++ b/CodeSnippets/InitializationAndDeinitialization.codesnippet
@@ -6,10 +6,10 @@
 	<string>Initialization and deinitialization</string>
 	<key>IDECodeSnippetCompletionScopes</key>
 	<array>
-		<string>StringOrComment</string>
+		<string>All</string>
 	</array>
 	<key>IDECodeSnippetContents</key>
-	<string>MARK: - Initialization and deinitialization</string>
+	<string>// MARK: - Initialization and deinitialization</string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>8B94553C-175D-42FB-BB94-B4E9D8CE3810</string>
 	<key>IDECodeSnippetLanguage</key>

--- a/CodeSnippets/InternalMethods.codesnippet
+++ b/CodeSnippets/InternalMethods.codesnippet
@@ -6,10 +6,10 @@
 	<string>Internal Helpers</string>
 	<key>IDECodeSnippetCompletionScopes</key>
 	<array>
-		<string>StringOrComment</string>
+		<string>All</string>
 	</array>
 	<key>IDECodeSnippetContents</key>
-	<string>MARK: - Internal methods</string>
+	<string>// MARK: - Internal methods</string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>6C632B06-7A85-4EE0-91EC-2C208BBAF27E</string>
 	<key>IDECodeSnippetLanguage</key>

--- a/CodeSnippets/PrivateHelpers.codesnippet
+++ b/CodeSnippets/PrivateHelpers.codesnippet
@@ -6,10 +6,10 @@
 	<string>Private helpers</string>
 	<key>IDECodeSnippetCompletionScopes</key>
 	<array>
-		<string>StringOrComment</string>
+		<string>All</string>
 	</array>
 	<key>IDECodeSnippetContents</key>
-	<string>MARK: - Private helpers</string>
+	<string>// MARK: - Private helpers</string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>8019B756-5867-4995-9CD1-FE695546E731</string>
 	<key>IDECodeSnippetLanguage</key>

--- a/CodeSnippets/Properties.codesnippet
+++ b/CodeSnippets/Properties.codesnippet
@@ -6,10 +6,10 @@
 	<string>Properties</string>
 	<key>IDECodeSnippetCompletionScopes</key>
 	<array>
-		<string>StringOrComment</string>
+		<string>All</string>
 	</array>
 	<key>IDECodeSnippetContents</key>
-	<string>MARK: - Properties</string>
+	<string>// MARK: - Properties</string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>A41F7A26-6620-439E-B14F-6920FCB714B9</string>
 	<key>IDECodeSnippetLanguage</key>

--- a/CodeSnippets/UITableViewCell.codesnippet
+++ b/CodeSnippets/UITableViewCell.codesnippet
@@ -6,10 +6,10 @@
 	<string>UITableViewCell</string>
 	<key>IDECodeSnippetCompletionScopes</key>
 	<array>
-		<string>StringOrComment</string>
+		<string>All</string>
 	</array>
 	<key>IDECodeSnippetContents</key>
-	<string>MARK: - UITableViewCell</string>
+	<string>// MARK: - UITableViewCell</string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>F92FD887-0CD9-4897-90EF-62D507D76C7A</string>
 	<key>IDECodeSnippetLanguage</key>

--- a/CodeSnippets/UIViewController.codesnippet
+++ b/CodeSnippets/UIViewController.codesnippet
@@ -6,10 +6,10 @@
 	<string>UIViewController</string>
 	<key>IDECodeSnippetCompletionScopes</key>
 	<array>
-		<string>StringOrComment</string>
+		<string>All</string>
 	</array>
 	<key>IDECodeSnippetContents</key>
-	<string>MARK: - UIViewController</string>
+	<string>// MARK: - UIViewController</string>
 	<key>IDECodeSnippetIdentifier</key>
 	<string>2C8AD754-858D-4862-9921-C1A261C8E5C7</string>
 	<key>IDECodeSnippetLanguage</key>
@@ -19,6 +19,6 @@
 	<key>IDECodeSnippetUserSnippet</key>
 	<true/>
 	<key>IDECodeSnippetVersion</key>
-	<integer>0</integer>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ rm -rf XcodeCodeSnippets
 
 ### List of snippets
 #### Comments
-* MARK: - Internal methods, `shortcut: Internal methods`
-* MARK: - Constants, `shortcut: Constants`
-* MARK: - IBOutlets, `shortcut: IBOutlets`
-* MARK: - IBActions, `shortcut: IBActions`
-* MARK: - Private helpers, `shortcut: Private helpers`
-* MARK: - Initialization and deinitialization, `shortcut: Initialization and deinitialization`
-* MARK: - Properties, `shortcut: Properties`
-* MARK: - NSLayoutConstraints, `shortcut: NSLayoutConstraints`
+* // MARK: - Internal methods, `shortcut: Internal methods`
+* // MARK: - Constants, `shortcut: Constants`
+* // MARK: - IBOutlets, `shortcut: IBOutlets`
+* // MARK: - IBActions, `shortcut: IBActions`
+* // MARK: - Private helpers, `shortcut: Private helpers`
+* // MARK: - Initialization and deinitialization, `shortcut: Initialization and deinitialization`
+* // MARK: - Properties, `shortcut: Properties`
+* // MARK: - NSLayoutConstraints, `shortcut: NSLayoutConstraints`
 #### Code
 * A template for creating TableViewAdapter, `shortcut: Table View Adapter`
   <details>
@@ -181,7 +181,7 @@ rm -rf XcodeCodeSnippets
 
 ### Author
 
-iSmetanin, smetanin23@yandex.ru
+Ivan Smetanin, smetanin23@yandex.ru
 
 ### License
 


### PR DESCRIPTION
#### Related issue #5 ####

#### Changes: ####
* Fix completion scope and content of comment snippets
* Add "//" to each snippet
* Fix README

#### Notes: ####
* Now code snippets works without "//" in "all" completion scopes